### PR TITLE
allow CC 0; highlight invalid values

### DIFF
--- a/src/components/EditControl.svelte
+++ b/src/components/EditControl.svelte
@@ -37,6 +37,10 @@
     margin: 0;
     margin-right: 5px;
   }
+
+  dd input:invalid {
+    background: #f99;
+  }
 </style>
 
 <dl class="config-column">
@@ -55,7 +59,7 @@
       type="number"
       bind:value={editControl.cc}
       on:change={touchControl}
-      min="1"
+      min="0"
       max="127" />
   </dd>
 </dl>


### PR DESCRIPTION
CC values 0-127 are legal, and entering 0 via text works, but the `input type="number"` range is limited to 1-127 and the up/down spinner controls won't allow you to reach 0.

Also added a line of CSS to give the input control a red background if the contents are outside the range.