### PR TITLE
Fixed 'update controller' not enabled when changing fader min/max

### DIFF
--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -16,7 +16,7 @@ export const isEquivalent = (
       optionEquivalents && configA.i2cLeader == configB.i2cLeader;
   }
 
-  if ("fadermax" in configA || "fadermax" in configB) {
+  if ("faderMax" in configA || "faderMax" in configB) {
     optionEquivalents =
       optionEquivalents &&
       configA.faderMax == configB.faderMax &&


### PR DESCRIPTION
When changing the 'Fader Minimum/Maximum raw value' settings the 'Update controller' button wasn't getting enabled. Looks like its just a typo/case issue